### PR TITLE
Improve PHP section with better references

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -5,5 +5,4 @@ Fue creado originalmente por Rasmus Lerdorf en 1995. Actualmente el lenguaje sig
 
 ###Recursos para Principiantes.
 * [PHP.net](http://www.php.net/) :free:
-* [w3schools](http://www.w3schools.com/PHP/) :free:
 * [Codeacademy](http://www.codecademy.com/tracks/php) :free:

--- a/PHP/README.md
+++ b/PHP/README.md
@@ -6,3 +6,5 @@ Fue creado originalmente por Rasmus Lerdorf en 1995. Actualmente el lenguaje sig
 ###Recursos para Principiantes.
 * [PHP.net](http://www.php.net/) :free:
 * [Codeacademy](http://www.codecademy.com/tracks/php) :free:
+* [PHPTheRightWay](http://www.phptherightway.com/) :free:
+* [ThePHPLeague](https://thephpleague.com/) :free:


### PR DESCRIPTION
W3 is a horrible source, a lot of things there are outdated, most of the time they provide examples with the worst possible practices and, also, all the references they provide can be found on PHP.net which is way better than W3.

PHPLeague has a lot of packages with neat code and a few guidelines for code quality (see https://thephpleague.com/#quality)

PHPTheRightWay is an excellent source for good practices (in general) and how to implement them in PHP.